### PR TITLE
Added socket verification to prevent crashes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,8 +137,10 @@
     };
   };
   Aria2.prototype.close = function() {
-    this.socket.close();
-    delete this.socket;
+    if(this.socket) {
+        this.socket.close();
+        delete this.socket;
+    }
   };
   Aria2.methods = [
     'addUri',


### PR DESCRIPTION
While creating lots and lots of RPC calls sometimes socket is not present on close and this cause a crash on my application.

I've added this patch to prevent crash so when socket is undefined we do nothing.