### PR TITLE
Fix bug: notification not work

### DIFF
--- a/lib/Aria2.js
+++ b/lib/Aria2.js
@@ -25,7 +25,7 @@ class Aria2 extends JSONRPCClient {
 
   _onnotification(notification) {
     const { method, params } = notification;
-    const event = unprefix(notification);
+    const event = unprefix(method);
     if (event !== method) this.emit(event, ...params);
     return super._onnotification(notification);
   }


### PR DESCRIPTION
simple test code will throw exception
```js
    const Aria2 = require("aria2");
    var options = {
        host: 'localhost',
        port: 6800,
        secure: false,
        secret: '',
        path: '/jsonrpc'
    }
    const aria2 = new Aria2(options);

     aria2
     .open()
     .then(() => console.log("open"))
     .catch(err => console.log("error", err));

    aria2.on("onDownloadStart", (params) =>
    {
        console.log('aria2', params)
    })

    const url = "http://www.github.com";
    const guid = await aria2.call("addUri", [url], { dir: "./tmp" });
```