### PR TITLE
Fix multicall

### DIFF
--- a/lib/Aria2.js
+++ b/lib/Aria2.js
@@ -35,10 +35,11 @@ class Aria2 extends JSONRPCClient {
   }
 
   async multicall(calls) {
-    const multi = calls.map(([method, ...params]) => {
-      return [{ methodName: prefix(method), params: this.addSecret(params) }];
-    });
-
+    const multi = [
+      calls.map(([method, ...params]) => {
+        return { methodName: prefix(method), params: this.addSecret(params) };
+      })
+    ];
     return super.call("system.multicall", multi);
   }
 

--- a/test/Aria2.js
+++ b/test/Aria2.js
@@ -25,8 +25,10 @@ test("#multicall", t => {
     t.deepEqual(m, {
       method: "system.multicall",
       params: [
-        [{ methodName: "aria2.a", params: ["token:foobar", "1", "2"] }],
-        [{ methodName: "aria2.b", params: ["token:foobar", "1", "2"] }]
+        [
+          { methodName: "aria2.a", params: ["token:foobar", "1", "2"] },
+          { methodName: "aria2.b", params: ["token:foobar", "1", "2"] }
+        ]
       ],
       id: 0,
       "json-rpc": "2.0"


### PR DESCRIPTION
The parameter passed in is an array of arrays, but all the calls are nested in the first array...

[Reference](https://aria2.github.io/manual/en/html/aria2c.html#system.multicall):

```py
>>> jsonreq = json.dumps({'jsonrpc':'2.0', 'id':'qwer',
...                       'method':'system.multicall',
...                       'params':[[{'methodName':'aria2.addUri',                        # <<
...                                   'params':[['http://example.org']]},
...                                  {'methodName':'aria2.addTorrent',
...                                   'params':[base64.b64encode(open('file.torrent').read())]}]]})
```
